### PR TITLE
Simplified SSH Key Management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/default-test-container:2.11.0
+FROM quay.io/ansible/default-test-container:3.0.0
 
 COPY files/requirements.sh /tmp/requirements-core.sh
 COPY requirements/*.txt /tmp/requirements-core/


### PR DESCRIPTION
SSH client keys are no longer generated. This is now the responsibility of ansible-test.