### PR TITLE
Restore Python 3.6 as the container default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/default-test-container:3.3.0
+FROM quay.io/ansible/default-test-container:3.4.0
 
 COPY files/requirements.sh /tmp/requirements-core.sh
 COPY requirements/*.txt /tmp/requirements-core/
@@ -7,7 +7,7 @@ COPY freeze/*.txt /tmp/freeze-core/
 RUN /tmp/requirements-core.sh 2.6
 RUN /tmp/requirements-core.sh 2.7
 RUN /tmp/requirements-core.sh 3.5
-RUN /tmp/requirements-core.sh 3.6
 RUN /tmp/requirements-core.sh 3.7
 RUN /tmp/requirements-core.sh 3.8
 RUN /tmp/requirements-core.sh 3.9
+RUN /tmp/requirements-core.sh 3.6


### PR DESCRIPTION
Update the base image, which switches back to Python 3.6 for the container default.