### PR TITLE
Drop `PyCrypto` on Python 3.10.

### DIFF
--- a/freeze/3.10.txt
+++ b/freeze/3.10.txt
@@ -23,7 +23,6 @@ ptyprocess==0.7.0
 py==1.10.0
 pyasn1==0.4.8
 pycparser==2.20
-pycrypto==2.6.1
 PyNaCl==1.4.0
 pyOpenSSL==20.0.1
 pyparsing==2.4.7

--- a/requirements/units.requirements.txt
+++ b/requirements/units.requirements.txt
@@ -1,4 +1,4 @@
-pycrypto
+pycrypto ; python_version < '3.10'  # pycrypto is not compatible with Python 3.10
 passlib
 pywinrm
 pytz


### PR DESCRIPTION
`PyCrypto` does not work on Python 3.10.